### PR TITLE
fix incorrect post number read over 1k posts

### DIFF
--- a/spec.js
+++ b/spec.js
@@ -42,6 +42,7 @@ describe('Instagram fast commenter', function() {
 
         // Convert value of posts on target profile from string to int
         var numberOfPostsInt = numberOfPostsString.replace('.','');
+        numberOfPostsInt.replace(' ','');
         numberOfPostsInt = parseInt(numberOfPostsInt, 10);
 
         if(numberOfPostsInt != numberOfPostsOnTargetProfile){


### PR DESCRIPTION
If page has more than 999 posts the bot leaves a space in the number.
Example: 1 100 instead of 1100